### PR TITLE
GAUD-9569: remove images-to-variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "postcss-cli": "^2.5.1",
     "rimraf": "^2.5.1",
     "vui-grid-system": "^0.0.1",
-    "vui-input": "^1.5.4",
-    "images-to-variables": "^0.3.0"
+    "vui-input": "^1.5.4"
   }
 }


### PR DESCRIPTION
Temporarily un-archived this repo so that we can remove the `images-to-variables` dependency, which I'd like to graveyard. This repo isn't using it and hasn't for quite some time.